### PR TITLE
Fix the `when` exhaustive case in  `DestinationsAppExtensions.kt`

### DIFF
--- a/playground/src/main/java/com/ramcosta/samples/playground/commons/DestinationsAppExtensions.kt
+++ b/playground/src/main/java/com/ramcosta/samples/playground/commons/DestinationsAppExtensions.kt
@@ -32,7 +32,8 @@ fun DirectionDestination.DrawerContent(
         }
         GoToProfileConfirmationDestination,
         SettingsScreenDestination,
-        ThemeSettingsDestination -> Unit
+        ThemeSettingsDestination,
+        ProfileSettingsScreenDestination -> Unit
     }
 }
 


### PR DESCRIPTION
Minor Fix for the `when` expression must be exhaustive, added the **` ProfileSettingsScreenDestination`** also for the case returning **`Unit`**

fixes #198 