### PR TITLE
Fixed deep links with no arguments using "baseRoute" instead of using the variable `baseRoute`

### DIFF
--- a/compose-destinations-codegen/src/main/java/com/ramcosta/composedestinations/codegen/writers/SingleDestinationWriter.kt
+++ b/compose-destinations-codegen/src/main/java/com/ramcosta/composedestinations/codegen/writers/SingleDestinationWriter.kt
@@ -339,7 +339,7 @@ class SingleDestinationWriter(
             }
         }
 
-        return if (args.isEmpty()) "baseRoute"
+        return if (args.isEmpty()) "\$baseRoute"
         else "\$baseRoute$mandatoryArgs$optionalArgs"
     }
 


### PR DESCRIPTION
This code:

```kotlin
@Destination(deepLinks = [DeepLink(uriPattern = "my-app-scheme://deeplink/$FULL_ROUTE_PLACEHOLDER")])
@Composable
fun MyScreen() { .. }
```

Produces this code in `MyScreenDestination.kt`:

```kotlin
@get:RestrictTo(RestrictTo.Scope.SUBCLASSES)
override val baseRoute = "my_screen"

override val route = baseRoute

override val deepLinks get() = listOf(
    navDeepLink {
        uriPattern = "my-app-scheme://deeplink/baseRoute"
    }
)
```

But it should produce this code:

```kotlin
@get:RestrictTo(RestrictTo.Scope.SUBCLASSES)
override val baseRoute = "my_screen"

override val route = baseRoute

override val deepLinks get() = listOf(
    navDeepLink {
        uriPattern = "my-app-scheme://deeplink/$baseRoute"
    }
)
```