### PR TITLE
Build every push using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+
+on:
+  push:
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: current
+          arguments: build


### PR DESCRIPTION
Adds a very basic GitHub action workflow that runs on every push (even on pull requests) and runs the `gradlew build` command.

It can be useful to see if a commit or pull request breaks the build without having to manually test the project.

I have to also note that the [build currently fails](https://github.com/yasan-org/compose-destinations/actions/runs/3072836796) for me as there is a lint issue on the sample app (on [TaskScreen](https://github.com/raamcosta/compose-destinations/blob/7b73468d2013d6d71edfbaf1542954b9faa2b7cb/sample/src/main/java/com/ramcosta/destinations/sample/tasks/presentation/details/TaskScreen.kt#L25)). You can fix the build by making lint issues not fail the build or suppress the lint issue using `@SuppressLint("UnusedMaterialScaffoldPaddingParameter")`.

You can see the action runs on my fork [here](https://github.com/yasan-org/compose-destinations/actions). After [suppressing the lint issue](https://github.com/yasan-org/compose-destinations/commit/b5b54f638c26db62e076d4d6e5c2977827a2523d) the [build was successful](https://github.com/yasan-org/compose-destinations/actions/runs/3072846649).

The action can be improved a lot to make it more useful but I suppose simply building the whole project is a good start.