### PR TITLE
Fix destination query string for multiple optional args

### DIFF
--- a/compose-destinations-codegen/src/main/java/com/ramcosta/composedestinations/codegen/writers/SingleDestinationWriter.kt
+++ b/compose-destinations-codegen/src/main/java/com/ramcosta/composedestinations/codegen/writers/SingleDestinationWriter.kt
@@ -187,6 +187,7 @@ class SingleDestinationWriter(
         var route = "\"${constructRoute(true)}\""
             .replace("/", "\" + \n\t\t\t\t\t\"/")
             .replace("?", "\" + \n\t\t\t\t\t\"?")
+            .replace("&", "\" + \n\t\t\t\t\t\"&")
 
         navArgs.forEach {
             route = route.replace("{${it.name}}", "\${${it.stringifyForNavigation()}}")
@@ -336,7 +337,8 @@ class SingleDestinationWriter(
             if (it.isMandatory) {
                 mandatoryArgs += "/{${it.name}}"
             } else {
-                optionalArgs += "?${it.name}={${it.name}}"
+                optionalArgs += if (optionalArgs.isEmpty()) { "?" } else { "&" }
+                optionalArgs += "${it.name}={${it.name}}"
             }
         }
 


### PR DESCRIPTION
I have two optional arguments in the destination and route string for it is generated wrong:

```kt
object EventDetailScreenDestination : TypedDestination<EventDetailArgsDelegate> {
    
    override fun invoke(navArgs: EventDetailArgsDelegate): Direction = with(navArgs) {
        invoke(eventId, date)
    }
     
    operator fun invoke(
		eventId: String? = null,
		date: LocalDate? = null,
    ): Direction {
        return object : Direction {
            override val route = "$baseRoute" + 
					"?eventId=${DestinationsStringNavType.serializeValue("eventId", eventId)}" + 
					"?date=${localDateNavType.serializeValue(date)}"
        }
    }
    
    @get:RestrictTo(RestrictTo.Scope.SUBCLASSES)
    override val baseRoute = "event"

    override val route = "$baseRoute?eventId={eventId}?date={date}"

    ...
}
```

There should be `&` before **date** arg.