### PR TITLE
fix(ksp): Fix NullPointerException for navArgsDelegate classes coming from class files

### DIFF
--- a/compose-destinations-ksp/src/main/kotlin/com/ramcosta/composedestinations/ksp/processors/KspToCodeGenDestinationsMapper.kt
+++ b/compose-destinations-ksp/src/main/kotlin/com/ramcosta/composedestinations/ksp/processors/KspToCodeGenDestinationsMapper.kt
@@ -59,8 +59,10 @@ class KspToCodeGenDestinationsMapper(
 
         val cleanRoute = destinationAnnotation.prepareRoute(composableName)
 
-        val navArgsDelegateTypeAndFile = destinationAnnotation.getNavArgsDelegateType(composableName)?.also {
-            sourceFilesById[it.second.fileName] = it.second
+        val navArgsDelegateTypeAndFile = destinationAnnotation.getNavArgsDelegateType(composableName)?.also { typeAndFile ->
+            typeAndFile.second?.let {
+                sourceFilesById[it.fileName] = it
+            }
         }
         sourceFilesById[containingFile!!.fileName] = containingFile
 
@@ -121,7 +123,7 @@ class KspToCodeGenDestinationsMapper(
 
     private fun KSAnnotation.getNavArgsDelegateType(
         composableName: String
-    ): Pair<NavArgsDelegateType?, KSFile>? = kotlin.runCatching {
+    ): Pair<NavArgsDelegateType?, KSFile?>? = kotlin.runCatching {
         val ksType = findArgumentValue<KSType>(DESTINATION_ANNOTATION_NAV_ARGS_DELEGATE_ARGUMENT)!!
 
         val ksClassDeclaration = ksType.declaration as KSClassDeclaration
@@ -142,7 +144,7 @@ class KspToCodeGenDestinationsMapper(
                     ksClassDeclaration.qualifiedName!!.asString(),
                 )
             ),
-            ksClassDeclaration.containingFile!!
+            ksClassDeclaration.containingFile
         )
     }.getOrElse {
         throw IllegalDestinationsSetup("There was an issue with '$DESTINATION_ANNOTATION_NAV_ARGS_DELEGATE_ARGUMENT'" +


### PR DESCRIPTION
We are making KMM application where our NavArgsDelegate class is from another module so there is no `ksClassDeclaration.containingFile` (no source -> only class file).

Currently there is an error because of that, but I think that is should work normally:

```
[ksp] com.ramcosta.composedestinations.codegen.commons.IllegalDestinationsSetup: There was an issue with 'navArgsDelegate' of composable 'PollEditScreen': make sure it is a class with a primary constructor.
	at com.ramcosta.composedestinations.ksp.processors.KspToCodeGenDestinationsMapper.getNavArgsDelegateType(KspToCodeGenDestinationsMapper.kt:148)
	at com.ramcosta.composedestinations.ksp.processors.KspToCodeGenDestinationsMapper.toDestination(KspToCodeGenDestinationsMapper.kt:62)
	at com.ramcosta.composedestinations.ksp.processors.KspToCodeGenDestinationsMapper.access$toDestination(KspToCodeGenDestinationsMapper.kt:14)
	at com.ramcosta.composedestinations.ksp.processors.KspToCodeGenDestinationsMapper$map$1.invoke(KspToCodeGenDestinationsMapper.kt:47)
	at com.ramcosta.composedestinations.ksp.processors.KspToCodeGenDestinationsMapper$map$1.invoke(KspToCodeGenDestinationsMapper.kt:47)
	at kotlin.sequences.TransformingSequence$iterator$1.next(Sequences.kt:210)
	at kotlin.sequences.SequencesKt___SequencesKt.toCollection(_Sequences.kt:787)
	at kotlin.sequences.SequencesKt___SequencesKt.toMutableList(_Sequences.kt:817)
	at kotlin.sequences.SequencesKt___SequencesKt.toList(_Sequences.kt:808)
	at com.ramcosta.composedestinations.ksp.processors.KspToCodeGenDestinationsMapper.map(KspToCodeGenDestinationsMapper.kt:47)
	at com.ramcosta.composedestinations.ksp.processors.Processor.process(Processor.kt:42)
	at com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension$doAnalysis$4$1.invoke(KotlinSymbolProcessingExtension.kt:237)
	at com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension$doAnalysis$4$1.invoke(KotlinSymbolProcessingExtension.kt:235)
	at com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension.handleException(KotlinSymbolProcessingExtension.kt:330)
	at com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension.doAnalysis(KotlinSymbolProcessingExtension.kt:235)
	at org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(TopDownAnalyzerFacadeForJVM.kt:123)
	at org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration$default(TopDownAnalyzerFacadeForJVM.kt:99)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler$analyze$1.invoke(KotlinToJVMBytecodeCompiler.kt:264)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler$analyze$1.invoke(KotlinToJVMBytecodeCompiler.kt:55)
	at org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport.analyzeAndReport(AnalyzerWithCompilerReport.kt:115)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.analyze(KotlinToJVMBytecodeCompiler.kt:255)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.compileModules$cli(KotlinToJVMBytecodeCompiler.kt:101)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.compileModules$cli$default(KotlinToJVMBytecodeCompiler.kt:60)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:157)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:52)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:94)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:43)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:101)
	at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1642)
	at jdk.internal.reflect.GeneratedMethodAccessor108.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(Unknown Source)
	at java.rmi/sun.rmi.transport.Transport$1.run(Unknown Source)
	at java.rmi/sun.rmi.transport.Transport$1.run(Unknown Source)
	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
	at java.rmi/sun.rmi.transport.Transport.serviceCall(Unknown Source)
	at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(Unknown Source)
	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(Unknown Source)
	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(Unknown Source)
	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.lang.NullPointerException
	at com.ramcosta.composedestinations.ksp.processors.KspToCodeGenDestinationsMapper.getNavArgsDelegateType(KspToCodeGenDestinationsMapper.kt:145)
	... 44 more
```

