### PR TITLE
Add support for @kotlinx serialization Serializable in Navigation Results

### DIFF
--- a/compose-destinations-codegen/src/main/java/com/ramcosta/composedestinations/codegen/validators/InitialValidator.kt
+++ b/compose-destinations-codegen/src/main/java/com/ramcosta/composedestinations/codegen/validators/InitialValidator.kt
@@ -249,9 +249,9 @@ class InitialValidator(
             Float::class.qualifiedName,
             Int::class.qualifiedName
         )
-        if (resultType.importable.qualifiedName !in primitives && !resultType.isSerializable && !resultType.isParcelable) {
+        if (resultType.importable.qualifiedName !in primitives && !resultType.isSerializable && !resultType.isParcelable && !resultType.isKtxSerializable) {
             throw IllegalDestinationsSetup("Composable $composableName, ${resultType.toTypeCode()}: " +
-                    "Result types must be one of: ${listOf("String", "Long", "Boolean", "Float", "Int", "Parcelable", "Serializable").joinToString(", ")}")
+                    "Result types must be one of: ${listOf("String", "Long", "Boolean", "Float", "Int", "Parcelable", "Serializable", "kotlinx.serialization.Serializable").joinToString(", ")}")
         }
     }
 

--- a/compose-destinations/build.gradle.kts
+++ b/compose-destinations/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     kotlin("android")
     id("com.vanniktech.maven.publish")
+    kotlin("plugin.serialization")
 }
 
 android {
@@ -48,4 +49,5 @@ android {
 
 dependencies {
     api(libs.compose.navigation)
+    api(libs.ktxSerializationJson)
 }

--- a/compose-destinations/src/main/java/com/ramcosta/composedestinations/result/EmptyResultBackNavigator.kt
+++ b/compose-destinations/src/main/java/com/ramcosta/composedestinations/result/EmptyResultBackNavigator.kt
@@ -10,7 +10,7 @@ class EmptyResultBackNavigator<R> : ResultBackNavigator<R> {
 
     override fun navigateBack(result: R, type: KType?) = Unit
 
-    override fun setResult(result: R, kType: KType?) = Unit
+    override fun setResult(result: R, type: KType?) = Unit
 
     override fun navigateBack() = Unit
 }

--- a/compose-destinations/src/main/java/com/ramcosta/composedestinations/result/EmptyResultBackNavigator.kt
+++ b/compose-destinations/src/main/java/com/ramcosta/composedestinations/result/EmptyResultBackNavigator.kt
@@ -1,14 +1,16 @@
 package com.ramcosta.composedestinations.result
 
+import kotlin.reflect.KType
+
 /**
  * Empty implementation of [ResultBackNavigator] to
  * use in previews and possibly testing.
  */
 class EmptyResultBackNavigator<R> : ResultBackNavigator<R> {
 
-    override fun navigateBack(result: R) = Unit
+    override fun navigateBack(result: R, type: KType?) = Unit
 
-    override fun setResult(result: R) = Unit
+    override fun setResult(result: R, kType: KType?) = Unit
 
     override fun navigateBack() = Unit
 }

--- a/compose-destinations/src/main/java/com/ramcosta/composedestinations/result/ResultBackNavigator.kt
+++ b/compose-destinations/src/main/java/com/ramcosta/composedestinations/result/ResultBackNavigator.kt
@@ -32,7 +32,7 @@ interface ResultBackNavigator<R> {
      * Check [com.ramcosta.composedestinations.result.ResultRecipient] to see
      * how to get the result.
      *
-     * For kotlinx.serialization result you must fill [type] parameter.
+     * @param type must be used only with @kotlinx.serialization.Serializable [result]
      */
     fun navigateBack(result: R, type: KType? = null)
 
@@ -45,7 +45,7 @@ interface ResultBackNavigator<R> {
      * If multiple calls are done, the last one will be the result sent back.
      * This also applies if you call [navigateBack] (with result) after calling this.
      *
-     * For kotlinx.serialization result you must fill [type] parameter.
+     * @param type must be used only with @kotlinx.serialization.Serializable [result]
      */
     fun setResult(result: R, type: KType? = null)
 

--- a/compose-destinations/src/main/java/com/ramcosta/composedestinations/result/ResultBackNavigator.kt
+++ b/compose-destinations/src/main/java/com/ramcosta/composedestinations/result/ResultBackNavigator.kt
@@ -2,8 +2,7 @@ package com.ramcosta.composedestinations.result
 
 import androidx.compose.runtime.*
 import androidx.navigation.NavController
-import com.ramcosta.composedestinations.dynamic.DynamicDestinationSpec
-import com.ramcosta.composedestinations.spec.DestinationSpec
+import kotlin.reflect.KType
 
 /**
  * Navigator that allows navigating back while passing
@@ -32,8 +31,10 @@ interface ResultBackNavigator<R> {
      *
      * Check [com.ramcosta.composedestinations.result.ResultRecipient] to see
      * how to get the result.
+     *
+     * For kotlinx.serialization result you must fill [type] parameter.
      */
-    fun navigateBack(result: R)
+    fun navigateBack(result: R, type: KType? = null)
 
     /**
      * Sets a [result] to be sent on the next [navigateBack] call.
@@ -43,8 +44,10 @@ interface ResultBackNavigator<R> {
      *
      * If multiple calls are done, the last one will be the result sent back.
      * This also applies if you call [navigateBack] (with result) after calling this.
+     *
+     * For kotlinx.serialization result you must fill [type] parameter.
      */
-    fun setResult(result: R)
+    fun setResult(result: R, type: KType? = null)
 
     /**
      * Goes back to previous destination sending the last result set with [setResult]


### PR DESCRIPTION
**Adds the #235 enhancement**

Kotlin's @kotlinx.serialization.Serializable types currently work as navigation arguments, but not for navigating back with a result using ResultBackNavigator and ResultRecipient. 
Which isn't really very useful when the rest of the library has support for it.
This PR tries to solve that.

If there is a better solution than adding another parameter I'm happy to improve it, unfortunately `reified` can only be used with inline functions and not with class parameters. And I'm not aware of a better solution
