### PR TITLE
fix(ksp): Nested and serializable typealiases

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ accompanist = "0.26.5-rc"
 ktxSerialization = "1.4.0"
 mockk = "1.13.2"
 
+compileTesting = "1.4.9"
 
 [plugins]
 dependencyCheckPlugin = { id = "com.github.ben-manes.versions", version.ref = "dependencyCheckPluginVersion" }
@@ -66,3 +67,5 @@ ktxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-j
 # Test
 test-junit = { module = "junit:junit", version.ref = "junit" }
 test-mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+test-kotlinCompile = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "compileTesting" }
+test-kotlinCompileKsp = { module = "com.github.tschuchortdev:kotlin-compile-testing-ksp", version.ref = "compileTesting" }

--- a/playground/build.gradle.kts
+++ b/playground/build.gradle.kts
@@ -107,4 +107,8 @@ dependencies {
 
     testImplementation(libs.test.junit)
     testImplementation(libs.test.mockk)
+
+    testImplementation(project(":compose-destinations-ksp"))
+    testImplementation(libs.test.kotlinCompile)
+    testImplementation(libs.test.kotlinCompileKsp)
 }

--- a/playground/src/test/kotlin/com/ramcosta/composedestinations/ksp/ProcessorProviderTests.kt
+++ b/playground/src/test/kotlin/com/ramcosta/composedestinations/ksp/ProcessorProviderTests.kt
@@ -1,0 +1,370 @@
+package com.ramcosta.composedestinations.ksp
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.SourceFile.Companion.kotlin
+import com.tschuchort.compiletesting.kspIncremental
+import com.tschuchort.compiletesting.kspSourcesDir
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ProcessorProviderTests {
+    @Rule
+    @JvmField
+    var temporaryFolder: TemporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `@Destination basic setup`() {
+        val compilation = prepareCompilation(
+            kotlin(
+                "Screen.kt",
+                """
+          package test
+
+          import com.ramcosta.composedestinations.annotation.Destination
+          import com.ramcosta.composedestinations.annotation.RootNavGraph
+
+          @RootNavGraph(start = true)
+          @Destination(route = "test1")
+          fun TestScreen1() {}
+
+          @Destination(route = "test2")
+          fun TestScreen2() {}
+          """.trimIndent()
+            )
+        )
+        val result = compilation.compile()
+
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
+        assertTrue(
+            compilation.kspSourcesDir.walkTopDown()
+                .filter { it.nameWithoutExtension == "TestScreen1Destination" || it.nameWithoutExtension == "TestScreen2Destination" }
+                .toList().isNotEmpty()
+        )
+    }
+
+    @Test
+    fun `@Destination should have at least one start`() {
+        val result = compile(
+            kotlin(
+                "Screen.kt",
+                """
+          package test
+
+          import com.ramcosta.composedestinations.annotation.Destination
+
+          @Destination(route = "test1")
+          fun TestScreen1() {}
+
+          @Destination(route = "test2")
+          fun TestScreen2() {}
+          """.trimIndent()
+            )
+        )
+
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertTrue(result.messages.contains("com.ramcosta.composedestinations.codegen.commons.IllegalDestinationsSetup: Use argument `start = true` in the @Destination annotation of the 'root' nav graph's start destination!"))
+    }
+
+    @Test
+    fun `@Destination with navArgsDelegate no serializable`() {
+        val result = compile(
+            kotlin(
+                "Screen.kt",
+                """
+          package com.ramcosta.composedestinations.example
+
+          import com.ramcosta.composedestinations.annotation.Destination
+          import com.ramcosta.composedestinations.annotation.RootNavGraph
+
+          data class NotSerializable(
+            val color: String
+          )
+
+          data class TestArgs(
+            val arg: NotSerializable
+          )
+
+          @RootNavGraph(start = true)
+          @Destination(route = "test1")
+          fun TestScreen1() {}
+
+          @Destination(route = "test2", navArgsDelegate = TestArgs::class)
+          fun TestScreen2(
+            navArgs: TestArgs
+          ) {}
+          """.trimIndent()
+            )
+        )
+
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertTrue(result.messages.contains("com.ramcosta.composedestinations.codegen.commons.IllegalDestinationsSetup: Composable 'TestScreen2': 'navArgsDelegate' cannot have arguments that are not navigation types."))
+    }
+
+    @Test
+    fun `@Destination with navArgsDelegate serializable`() {
+        val compilation = prepareCompilation(
+            kotlin(
+                "Screen.kt",
+                """
+          package com.ramcosta.composedestinations.example
+
+          import com.ramcosta.composedestinations.annotation.Destination
+          import kotlinx.serialization.Serializable
+          import com.ramcosta.composedestinations.annotation.RootNavGraph
+
+          @Serializable
+          data class IsSerializable(
+            val color: String
+          )
+
+          data class TestArgs(
+            val arg: IsSerializable
+          )
+
+          @RootNavGraph(start = true)
+          @Destination(route = "test1")
+          fun TestScreen1() {}
+
+          @Destination(route = "test2", navArgsDelegate = TestArgs::class)
+          fun TestScreen2(
+            navArgs: TestArgs
+          ) {}
+          """.trimIndent()
+            )
+        )
+
+        val result = compilation.compile()
+
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
+        assertTrue(
+            compilation.kspSourcesDir.walkTopDown()
+                .filter { it.nameWithoutExtension == "TestScreen1Destination" || it.nameWithoutExtension == "TestScreen2Destination" }
+                .toList().isNotEmpty()
+        )
+    }
+
+    @Test
+    fun `@Destination with navArgsDelegate non serializable typealias`() {
+        val result = compile(
+            kotlin(
+                "Screen.kt",
+                """
+          package com.ramcosta.composedestinations.example
+
+          import com.ramcosta.composedestinations.annotation.Destination
+          import com.ramcosta.composedestinations.annotation.RootNavGraph
+
+          data class NotSerializable(
+            val color: String
+          )
+
+          typealias Aliased = NotSerializable
+
+          data class TestArgs(
+            val arg: Aliased
+          )
+
+          @RootNavGraph(start = true)
+          @Destination(route = "test1")
+          fun TestScreen1() {}
+
+          @Destination(route = "test2", navArgsDelegate = TestArgs::class)
+          fun TestScreen2(
+            navArgs: TestArgs
+          ) {}
+          """.trimIndent()
+            )
+        )
+
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertTrue(result.messages.contains("com.ramcosta.composedestinations.codegen.commons.IllegalDestinationsSetup: Composable 'TestScreen2': 'navArgsDelegate' cannot have arguments that are not navigation types."))
+    }
+
+    @Test
+    fun `@Destination with navArgsDelegate serializable typealias`() {
+        val compilation = prepareCompilation(
+            kotlin(
+                "Screen.kt",
+                """
+          package com.ramcosta.composedestinations.example
+
+          import com.ramcosta.composedestinations.annotation.Destination
+          import com.ramcosta.composedestinations.annotation.RootNavGraph
+          import kotlinx.serialization.Serializable
+
+          @Serializable
+          data class IsSerializable(
+            val color: String
+          )
+
+          typealias Aliased = IsSerializable
+
+          data class TestArgs(
+            val arg: Aliased
+          )
+
+          @RootNavGraph(start = true)
+          @Destination(route = "test1")
+          fun TestScreen1() {}
+
+          @Destination(route = "test2", navArgsDelegate = TestArgs::class)
+          fun TestScreen2(
+            navArgs: TestArgs
+          ) {}
+          """.trimIndent()
+            )
+        )
+
+        val result = compilation.compile()
+
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
+        assertTrue(
+            compilation.kspSourcesDir.walkTopDown()
+                .filter { it.nameWithoutExtension == "TestScreen1Destination" || it.nameWithoutExtension == "TestScreen2Destination" }
+                .toList().isNotEmpty()
+        )
+    }
+
+    @Test
+    fun `@Destination with navArgsDelegate annotated serializable typealias`() {
+        val compilation = prepareCompilation(
+            kotlin(
+                "Screen.kt",
+                """
+          package com.ramcosta.composedestinations.example
+
+          import com.ramcosta.composedestinations.annotation.Destination
+          import com.ramcosta.composedestinations.annotation.RootNavGraph
+          import kotlinx.serialization.Serializable
+
+          data class IsSerializable(
+            val color: String
+          )
+
+          typealias Aliased = @Serializable IsSerializable
+
+          data class TestArgs(
+            val arg: Aliased
+          )
+
+          @RootNavGraph(start = true)
+          @Destination(route = "test1")
+          fun TestScreen1() {}
+
+          @Destination(route = "test2", navArgsDelegate = TestArgs::class)
+          fun TestScreen2(
+            navArgs: TestArgs
+          ) {}
+          """.trimIndent()
+            )
+        )
+
+        val result = compilation.compile()
+
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
+        assertTrue(
+            compilation.kspSourcesDir.walkTopDown()
+                .filter { it.nameWithoutExtension == "TestScreen1Destination" || it.nameWithoutExtension == "TestScreen2Destination" }
+                .toList().isNotEmpty()
+        )
+    }
+
+    @Test
+    fun `@Destination with navArgsDelegate simple typealias`() {
+        val compilation = prepareCompilation(
+            kotlin(
+                "Screen.kt",
+                """
+          package com.ramcosta.composedestinations.example
+
+          import com.ramcosta.composedestinations.annotation.Destination
+          import com.ramcosta.composedestinations.annotation.RootNavGraph
+
+          typealias Aliased = String
+
+          data class TestArgs(
+            val arg: Aliased
+          )
+
+          @RootNavGraph(start = true)
+          @Destination(route = "test1")
+          fun TestScreen1() {}
+
+          @Destination(route = "test2", navArgsDelegate = TestArgs::class)
+          fun TestScreen2(
+            navArgs: TestArgs
+          ) {}
+          """.trimIndent()
+            )
+        )
+
+        val result = compilation.compile()
+
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
+        assertTrue(
+            compilation.kspSourcesDir.walkTopDown()
+                .filter { it.nameWithoutExtension == "TestScreen1Destination" || it.nameWithoutExtension == "TestScreen2Destination" }
+                .toList().isNotEmpty()
+        )
+    }
+
+    @Test
+    fun `@Destination with navArgsDelegate double typealias`() {
+        val compilation = prepareCompilation(
+            kotlin(
+                "Screen.kt",
+                """
+          package com.ramcosta.composedestinations.example
+
+          import com.ramcosta.composedestinations.annotation.Destination
+          import com.ramcosta.composedestinations.annotation.RootNavGraph
+
+          typealias Aliased = String
+          typealias AliasedSecond = Aliased
+
+          data class TestArgs(
+            val arg: AliasedSecond
+          )
+
+          @RootNavGraph(start = true)
+          @Destination(route = "test1")
+          fun TestScreen1() {}
+
+          @Destination(route = "test2", navArgsDelegate = TestArgs::class)
+          fun TestScreen2(
+            navArgs: TestArgs
+          ) {}
+          """.trimIndent()
+            )
+        )
+
+        val result = compilation.compile()
+
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
+        assertTrue(
+            compilation.kspSourcesDir.walkTopDown()
+                .filter { it.nameWithoutExtension == "TestScreen1Destination" || it.nameWithoutExtension == "TestScreen2Destination" }
+                .toList().isNotEmpty()
+        )
+    }
+
+    private fun prepareCompilation(vararg sourceFiles: SourceFile): KotlinCompilation {
+        return KotlinCompilation().apply {
+            workingDir = temporaryFolder.root
+            inheritClassPath = true
+            symbolProcessorProviders = listOf(ProcessorProvider())
+            sources = sourceFiles.asList()
+            verbose = false
+            kspIncremental = false
+        }
+    }
+
+    private fun compile(vararg sourceFiles: SourceFile): KotlinCompilation.Result {
+        return prepareCompilation(*sourceFiles).compile()
+    }
+}


### PR DESCRIPTION
I'm using KMM library for [UUIDs](https://github.com/benasher44/uuid) which define own type as: `typealias Uuid = java.util.UUID`. I have my own typealias `typealias EventId = Uuid` for better readability, which I want to use in the navigation, but it is not correctly detected as Serializable.

`@Serializable` annotation on `typealias` is not correctly detected too.

I have added basic failing tests and then rewrite the detection.
