### PR TITLE
fix: Generated package name when using hard keyword 'is'

### DIFF
--- a/compose-destinations-codegen/src/main/java/com/ramcosta/composedestinations/codegen/commons/Utils.kt
+++ b/compose-destinations-codegen/src/main/java/com/ramcosta/composedestinations/codegen/commons/Utils.kt
@@ -26,9 +26,13 @@ fun String.removeInstancesOf(vararg toRemove: String): String {
     return result
 }
 
+private val keywords: Set<String> = setOf(
+    "in", "is"
+)
+
 fun String.sanitizePackageName(): String {
     return split(".")
-        .joinToString(".") { if (it == "in") "`in`" else it }
+        .joinToString(".") { if (keywords.contains(it)) "`$it`" else it }
 }
 
 private val humps = "(?<=.)(?=\\p{Upper})".toRegex()


### PR DESCRIPTION
Adds the Kotlin keyword `is` to the package name sanitizer list, solving issues similar to #137 for those using Iceland's TLD in their package names.  