### PR TITLE
:bug: Fix hidden IllegalDestinationsSetup error

### DIFF
--- a/compose-destinations-ksp/src/main/kotlin/com/ramcosta/composedestinations/ksp/commons/Utils.kt
+++ b/compose-destinations-ksp/src/main/kotlin/com/ramcosta/composedestinations/ksp/commons/Utils.kt
@@ -119,11 +119,13 @@ fun KSType.findActualClassDeclaration(): KSClassDeclaration? {
     return declaration as? KSClassDeclaration?
 }
 
-fun KSClassDeclaration.toImportable(): Importable {
-    return Importable(
-        simpleName.asString(),
-        qualifiedName!!.asString()
-    )
+fun KSClassDeclaration.toImportable(): Importable? {
+    return qualifiedName?.let { nonNullQualifiedName ->
+        Importable(
+            simpleName.asString(),
+            nonNullQualifiedName.asString()
+        )
+    }
 }
 
 val KSClassDeclaration.isNothing get() =


### PR DESCRIPTION
The error is thrown when the destination style isn't resolved but this is hidden by a `NullPointerException` from the `toImportable` function.

The fix was simply to mark the `toImportable` function as nullable and add a check around the `qualifiedName` variable

This fixes #654 