### PR TITLE
fix: Mermaid graph diagram init

### DIFF
--- a/compose-destinations-codegen/src/main/java/com/ramcosta/composedestinations/codegen/writers/MermaidGraphWriter.kt
+++ b/compose-destinations-codegen/src/main/java/com/ramcosta/composedestinations/codegen/writers/MermaidGraphWriter.kt
@@ -32,7 +32,7 @@ internal class MermaidGraphWriter(
             appendLine("---")
             appendLine("title: $title")
             appendLine("---")
-            appendLine("%%{init: {'theme':'base', 'themeVariables': { 'primaryTextColor': '#fff' }}%%")
+            appendLine("%%{init: {'theme':'base', 'themeVariables': { 'primaryTextColor': '#fff' }}}%%")
             appendLine("graph TD")
             appendGraphTreeLinks(tree)
             appendLine()


### PR DESCRIPTION
The mermaid diagram javascript init code was missing a closing curly bracket. 
This commit adds the missing bracket.